### PR TITLE
Support both `UnremovableABM` and `StandardABM`

### DIFF
--- a/examples/Analysis/msd_runtumble.jl
+++ b/examples/Analysis/msd_runtumble.jl
@@ -12,7 +12,7 @@ U = 30.0 # μm/s
 τ = 1.0 # s 
 turn_rate = 1 / τ
 
-models = map(_ -> ABM(Microbe{3}, extent, dt), θs)
+models = map(_ -> UnremovableABM(Microbe{3}, extent, dt), θs)
 nmicrobes = 100
 for (i,θ) in enumerate(θs)
     motility = RunTumble(speed=[U], polar=[θ,-θ])

--- a/examples/Analysis/velocity_autocorrelations.jl
+++ b/examples/Analysis/velocity_autocorrelations.jl
@@ -8,7 +8,7 @@ turn_rate = 1 / τ_run # 1/s
 L = 1e4 # μm
 extent = (L,L,L)
 
-model = ABM(Microbe{3}, extent, Δt)
+model = UnremovableABM(Microbe{3}, extent, Δt)
 n = 200
 for i in 1:n
     add_agent!(model; turn_rate, motility=RunTumble(speed=[U]))

--- a/examples/Chemotaxis/xie_2D.jl
+++ b/examples/Chemotaxis/xie_2D.jl
@@ -23,7 +23,7 @@ properties = Dict(
 )
 
 rng = MersenneTwister(12)
-model = ABM(Xie{2}, extent, timestep; rng, properties, periodic=false)
+model = UnremovableABM(Xie{2}, extent, timestep; rng, properties, periodic=false)
 foreach(_ -> add_agent!(model; chemotactic_precision=6.0), 1:300)
 
 nsteps = 5000

--- a/examples/Chemotaxis/xie_response-function.jl
+++ b/examples/Chemotaxis/xie_response-function.jl
@@ -28,7 +28,7 @@ properties = Dict(
     :t₂ => t₂,
 )
 
-model = ABM(Xie{3}, extent, timestep; properties)
+model = UnremovableABM(Xie{3}, extent, timestep; properties)
 add_agent!(model; turn_rate_forward=0, motility=RunReverseFlick(motile_state=MotileState(Forward)))
 add_agent!(model; turn_rate_backward=0, motility=RunReverseFlick(motile_state=MotileState(Backward)))
 

--- a/examples/Encounters/sphere3D.jl
+++ b/examples/Encounters/sphere3D.jl
@@ -32,7 +32,7 @@ function setupmodel(R, L, n; dt=0.1, rng=Xoshiro(1))
         :sphere => HyperSphere(extent./2, R),
         :encounters => 0,
     )
-    model = ABM(Microbe{3}, extent, dt; properties, rng)
+    model = UnremovableABM(Microbe{3}, extent, dt; properties, rng)
     foreach(_ -> add_agent!(model; turn_rate=2.0), 1:n)
     model → encounters!
     model.properties[:old_positions] = map(m -> m.pos, allagents(model))

--- a/examples/Pathfinder/chemotaxis_porous-medium.jl
+++ b/examples/Pathfinder/chemotaxis_porous-medium.jl
@@ -43,7 +43,7 @@ properties = Dict(
     :C₂ => C₂,
 )
 
-model = ABM(BrownBerg{2}, extent, dt; periodic=false, properties)
+model = UnremovableABM(BrownBerg{2}, extent, dt; periodic=false, properties)
 pathfinder!(model, wm)
 foreach(_ -> add_agent!((0.0, rand()*extent[2]), model), 1:nbacteria)
 adata = [:pos]

--- a/examples/Pathfinder/randomwalk_porous-medium.jl
+++ b/examples/Pathfinder/randomwalk_porous-medium.jl
@@ -20,7 +20,7 @@ bodies = [
 ]
 wm = walkmap(bodies, extent, min_radius/25, 0)
 
-model = ABM(BrownBerg{2}, extent, dt; periodic=false)
+model = UnremovableABM(BrownBerg{2}, extent, dt; periodic=false)
 pathfinder!(model, wm)
 foreach(_ -> add_agent!(model), 1:nbacteria)
 adata = [:pos]

--- a/src/pathfinder.jl
+++ b/src/pathfinder.jl
@@ -1,6 +1,6 @@
 export pathfinder!, initialise_pathfinder, pathfinder_step!
 
-function pathfinder!(model::ABM, walkmap::BitArray)
+function pathfinder!(model::AgentBasedModel, walkmap::BitArray)
     pathfinder = initialise_pathfinder(model.space, walkmap)
     model.properties[:pathfinder] = pathfinder
 end
@@ -27,7 +27,7 @@ end
 Perform an integration step for `microbe` motion with pathfinding
 (`model.pathfinder`).
 """
-function pathfinder_step!(microbe::AbstractMicrobe, model::ABM, dt::Real)
+function pathfinder_step!(microbe::AbstractMicrobe, model::AgentBasedModel, dt::Real)
     U = microbe.speed
     target_position = @. microbe.pos + U*microbe.vel*dt
     plan_route!(microbe, target_position, model.pathfinder)

--- a/src/pathfinder.jl
+++ b/src/pathfinder.jl
@@ -23,7 +23,7 @@ function initialise_pathfinder(space::ContinuousSpace{D}, walkmap::BitArray{D}) 
 end
 
 """
-    pathfinder_step!(microbe::AbstractMicrobe, model::ABM, dt::Real)
+    pathfinder_step!(microbe::AbstractMicrobe, model::AgentBasedModel, dt::Real)
 Perform an integration step for `microbe` motion with pathfinding
 (`model.pathfinder`).
 """

--- a/test/analysis.jl
+++ b/test/analysis.jl
@@ -12,7 +12,7 @@ using LinearAlgebra: norm
         motility = RunTumble(speed=[U])
         vel = ntuple(_ -> 1/√D, D)
         turn_rate = 0
-        model = ABM(Microbe{D}, extent, dt)
+        model = StandardABM(Microbe{D}, extent, dt)
         add_agent!(pos, model; vel, motility, turn_rate)
         nsteps = 10
         adata = [:pos]
@@ -35,11 +35,11 @@ using LinearAlgebra: norm
             adata = [v]
             L = 100; extent = ntuple(_ -> L, D)
             rng = Xoshiro(35)
-            model_periodic = ABM(Microbe{D}, extent, dt; rng)
+            model_periodic = StandardABM(Microbe{D}, extent, dt; rng)
             add_agent!(model_periodic)
             adf_periodic, = run!(model_periodic, nsteps; adata)
             rng = Xoshiro(35)
-            model_closed = ABM(Microbe{D}, extent, dt; periodic=false, rng)
+            model_closed = StandardABM(Microbe{D}, extent, dt; periodic=false, rng)
             add_agent!(model_closed)
             adf_closed, = run!(model_closed, nsteps; adata)
             # boundary conditions don't affect vacf
@@ -59,7 +59,7 @@ using LinearAlgebra: norm
             dt = 0.1
             L = 100; extent = ntuple(_ -> L, D)
             turn_rate = 0 # ballistic motion
-            model = ABM(Microbe{D}, extent, dt)
+            model = StandardABM(Microbe{D}, extent, dt)
             add_agent!(model; turn_rate)
             nsteps = 50
             adata = [:pos]
@@ -74,7 +74,7 @@ using LinearAlgebra: norm
                 L₀ = 100; L₁ = 40
                 extent = ntuple(i -> i==1 ? L₀ : L₁, D)
                 turn_rate = 0 # ballistic motion
-                model = ABM(Microbe{D}, extent, dt)
+                model = StandardABM(Microbe{D}, extent, dt)
                 add_agent!(model; turn_rate)
                 nsteps = 50
                 adata = [:pos]
@@ -86,7 +86,7 @@ using LinearAlgebra: norm
 
             motility = RunReverse()
             turn_rate = Inf # reversal at each step
-            model = ABM(Microbe{D}, extent, dt)
+            model = StandardABM(Microbe{D}, extent, dt)
             add_agent!(extent./2, model; motility, turn_rate)
             nsteps = 5
             adata = [:pos]

--- a/test/microbe-creation.jl
+++ b/test/microbe-creation.jl
@@ -57,7 +57,7 @@ using LinearAlgebra: norm
             @test m.speed == 30.0
             @test m.motility isa RunTumble
 
-            model = ABM(BrownBerg{D}, ntuple(_->100,D), 0.1)
+            model = StandardABM(BrownBerg{D}, ntuple(_->100,D), 0.1)
             add_agent!(model)
             m = model[1]
             @test turnrate(m, model) == m.turn_rate*exp(-m.motor_gain*m.state)
@@ -81,7 +81,7 @@ using LinearAlgebra: norm
             @test m.speed == 46.5
             @test m.motility isa RunReverseFlick
 
-            model = ABM(Brumley{D}, ntuple(_->100,D), 0.1)
+            model = StandardABM(Brumley{D}, ntuple(_->100,D), 0.1)
             add_agent!(model)
             m = model[1]
             @test turnrate(m, model) == (1+exp(-m.motor_gain*m.state))*m.turn_rate/2
@@ -103,7 +103,7 @@ using LinearAlgebra: norm
             @test m.speed == 30.0
             @test m.motility isa RunTumble
             
-            model = ABM(Celani{D}, ntuple(_->100,D), 0.1)
+            model = StandardABM(Celani{D}, ntuple(_->100,D), 0.1)
             add_agent!(model)
             m = model[1]
             @test turnrate(m,model) == m.turn_rate*m.state[4]

--- a/test/model.jl
+++ b/test/model.jl
@@ -77,10 +77,10 @@ using LinearAlgebra: norm
     end
 
     @testset "Stepping" begin
-        for D in 1:3
+        for D in 1:3, ABM in (StandardABM, UnremovableABM)
             dt = 1
             extent = ntuple(_ -> 300, D)
-            model = StandardABM(Microbe{D}, extent, dt)
+            model = ABM(Microbe{D}, extent, dt)
             pos = extent ./ 2
             vel1 = rand_vel(D)
             speed1 = rand_speed(RunTumble())
@@ -107,7 +107,7 @@ using LinearAlgebra: norm
             # customize microbe affect! function
             # decreases microbe state value by D at each step
             MicrobeAgents.affect!(microbe::Microbe{D}, model) = (microbe.state-=D)
-            model = StandardABM(Microbe{D}, extent, dt)
+            model = ABM(Microbe{D}, extent, dt)
             add_agent!(model)
             run!(model)
             @test model[1].state == -D
@@ -118,13 +118,13 @@ using LinearAlgebra: norm
             @test model[1].state == -D
 
             # customize model.update! function
-            model = StandardABM(Microbe{D}, extent, dt)
-            tick_more!(model::StandardABM) = (model.t += 3)
+            model = ABM(Microbe{D}, extent, dt)
+            tick_more!(model) = (model.t += 3)
             model → tick_more! # now model.t increases by 4 (+1 +3) at each step
             run!(model, 6)
             @test model.t == 6*4
-            decrease!(model::StandardABM) = (model.t -= 1)
-            model = StandardABM(Microbe{D}, extent, dt)
+            decrease!(model) = (model.t -= 1)
+            model = ABM(Microbe{D}, extent, dt)
             # chain arbitrary number of functions
             model → tick_more! → decrease! → decrease! → decrease!
             # now we should be back at only +1 per step

--- a/test/spheres.jl
+++ b/test/spheres.jl
@@ -6,7 +6,7 @@ using Random
     dt = 1.0
     for D in 1:3
         extent = ntuple(_ -> L, D)
-        model = ABM(Microbe{D}, extent, dt)
+        model = StandardABM(Microbe{D}, extent, dt)
 
         c1 = extent ./ 2
         r1 = 30.0

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -36,7 +36,7 @@ using Random
             extent = ntuple(_ -> L, D)
 
             # periodic
-            model = ABM(Microbe{D}, extent, dt)
+            model = StandardABM(Microbe{D}, extent, dt)
             x₁ = ntuple(i -> i==1 ? 1.0 : 0.0, D)
             x₂ = ntuple(i -> i==1 ? L-1 : 0.0, D)
             add_agent!(x₁, model)
@@ -53,7 +53,7 @@ using Random
 
             # closed box
             # periodic
-            model = ABM(Microbe{D}, extent, dt; periodic=false)
+            model = StandardABM(Microbe{D}, extent, dt; periodic=false)
             x₁ = ntuple(i -> i==1 ? 1.0 : 0.0, D)
             x₂ = ntuple(i -> i==1 ? L-1 : 0.0, D)
             add_agent!(x₁, model)


### PR DESCRIPTION
MicrobeAgents now will only provide minor convenience functions upon the Agents interface.

- No more `MBM` type to wrap `UnremovableABM`
- No overloading of `ABM`
- `run!` is extended to all `AgentBasedModel` types, as long as their agent type is an `AbstractMicrobe`.