### PR TITLE
Implement barebones interface to CellListMap.jl for neighbor lists

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 Agents = "46ada45e-f475-11e8-01d0-f70cc89e6671"
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
+CellListMap = "69e1c6dd-3888-40e6-b3c8-31ac5f578864"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"

--- a/src/MicrobeAgents.jl
+++ b/src/MicrobeAgents.jl
@@ -1,6 +1,7 @@
 module MicrobeAgents
 
 using Agents
+using CellListMap.PeriodicSystems
 using Distributions
 using LinearAlgebra
 using Random
@@ -35,6 +36,7 @@ include("utils.jl")
 include("distributions.jl")
 include("motility.jl")
 include("rotations.jl")
+include("neighborlists.jl")
 
 include("microbes.jl")
 include("microbe_step.jl")

--- a/src/neighborlists.jl
+++ b/src/neighborlists.jl
@@ -17,7 +17,7 @@ Initialise a neighbor list between the microbes in `model` and the objects `y`
 with neighbor radius `cutoff` and add it to the `model` properties with name `key`.
 """
 function neighborlist!(model::ABM, y, cutoff, key)
-    model.properties[key] = neighborlist(model, y, cutoff)
+    abmproperties(model)[key] = neighborlist(model, y, cutoff)
 end
 
 
@@ -82,9 +82,10 @@ function update_neighborlist!(model, listkey)
     end
 end
 function update_neighborlist!(microbe::AbstractMicrobe, model, listkey)
-    neighbor_list = model.properties[listkey]
+    neighbor_list = abmproperties(model)[listkey]
     neighbor_list.xpositions[microbe.id] = SVector(microbe.pos)
 end
+
 
 @inline function make_position_vector(model::UnremovableABM)
     [SVector(_pos(a)) for a in allagents(model)]

--- a/src/neighborlists.jl
+++ b/src/neighborlists.jl
@@ -1,0 +1,82 @@
+export neighborlist!, update_neighborlist!
+
+"""
+    neighborlist!(model::ABM, x::AbstractVector, cutoff::Real, key::Symbol)
+
+Initialise a neighbor list between objects `x` with neighbor radius `cutoff` and
+add it to the `model` properties with name `key`.
+"""
+function neighborlist!(model::ABM, x::AbstractVector, cutoff::Real, key::Symbol)
+    model.properties[key] = neighborlist(x, model.space, cutoff)
+end
+"""
+    neighborlist!(model::ABM, x::AbstractVector, y::AbstractVector, cutoff::Real, key::Symbol)
+
+Initialise a neighbor list between objects `x` and `y` with neighbor radius `cutoff` and
+add it to the `model` properties with name `key`.
+"""
+function neighborlist!(model::ABM, x::AbstractVector, y::AbstractVector, cutoff::Real, key::Symbol)
+    model.properties[key] = neighborlist(x, y, model.space, cutoff)
+end
+
+neighborlist(x::AbstractVector, model::ABM, cutoff::Real) =
+    neighborlist(x, model.space, cutoff)
+neighborlist(x::AbstractVector, y::AbstractVector, model::ABM, cutoff::Real) =
+    neighborlist(x, y, model.space, cutoff)
+"""
+    function neighborlist(x::AbstractVector, space::ContinuousSpace, cutoff::Real)
+
+Initialise a neighbor list between objects in the vector `x` in `space`
+using a neighbor radius `cutoff`.
+"""
+function neighborlist(
+    x::AbstractVector, space::ContinuousSpace{D,P}, cutoff::Real
+) where {D,P}
+    pos_x = [SVector{length(xᵢ)}(xᵢ) for xᵢ in _pos.(x)]
+    PeriodicSystem(
+        xpositions = pos_x,
+        # if space is not periodic the unitcell size must be extended by cutoff
+        unitcell = SVector(spacesize(space) .+ (P ? 0.0 : cutoff)),
+        cutoff = cutoff,
+        output = 0.0
+    )
+end
+"""
+    function neighborlist(x::AbstractVector, y::AbstractVector, space::ContinuousSpace, cutoff::Real)
+
+Initialise a neighbor list between objects in the vectors `x` and `y` in `space`
+using a neighbor radius `cutoff`.
+"""
+function neighborlist(
+    x::AbstractVector, y::AbstractVector,
+    space::ContinuousSpace{D,P}, cutoff::Real
+) where {D,P}
+    pos_x = [SVector{length(xᵢ)}(xᵢ) for xᵢ in _pos.(x)]
+    pos_y = [SVector{length(yᵢ)}(yᵢ) for yᵢ in _pos.(y)]
+    PeriodicSystem(
+        xpositions = pos_x,
+        ypositions = pos_y,
+        # if space is not periodic the unitcell size must be extended by cutoff
+        unitcell = SVector(spacesize(space) .+ (P ? 0.0 : cutoff)),
+        cutoff = cutoff,
+        output = 0.0
+    )
+end
+
+
+"""
+    update_neighborlist!(model, listkey)
+
+Updates the position of all microbes in the neighbor list stored in `model.properties[listkey]`.
+This function assumes that the positions of microbes have been passed
+as the `x` argument to `neighborlist!`.
+"""
+function update_neighborlist!(model, listkey)
+    for microbe in allagents(model)
+        update_neighborlist!(microbe, model, listkey)
+    end
+end
+function update_neighborlist!(microbe::AbstractMicrobe, model, listkey)
+    neighbor_list = model.properties[listkey]
+    neighbor_list.xpositions[microbe.id] = SVector(microbe.pos)
+end

--- a/src/neighborlists.jl
+++ b/src/neighborlists.jl
@@ -5,8 +5,14 @@ export neighborlist!, update_neighborlist!
 
 Initialise a neighbor list of the microbes in `model` with neighbor radius `cutoff` and
 add it to the `model` properties with name `key`.
+
+*Neighbor lists are not supported in 1-dimensional models.*
 """
 function neighborlist!(model::ABM, cutoff::Real, key::Symbol)
+    D = length(spacesize(model))
+    if D == 1
+        throw(ArgumentError("Neighbor lists are not supported in 1-dimensional models."))
+    end
     abmproperties(model)[key] = neighborlist(model, cutoff)
 end
 
@@ -15,8 +21,14 @@ end
 
 Initialise a neighbor list between the microbes in `model` and the objects `y`
 with neighbor radius `cutoff` and add it to the `model` properties with name `key`.
+
+*Neighbor lists are not supported in 1-dimensional models.*
 """
 function neighborlist!(model::ABM, y, cutoff, key)
+    D = length(spacesize(model))
+    if D == 1
+        throw(ArgumentError("Neighbor lists are not supported in 1-dimensional models."))
+    end
     abmproperties(model)[key] = neighborlist(model, y, cutoff)
 end
 

--- a/test/neighborlists.jl
+++ b/test/neighborlists.jl
@@ -1,0 +1,63 @@
+using Test
+using MicrobeAgents
+using Agents
+using StaticArrays
+
+@testset "Neighbor Lists" begin
+    @testset "StandardABM" begin
+        for D in 2:3
+            L = 100
+            extent = ntuple(_->L, D)
+            dt = 1
+            model = StandardABM(Microbe{D}, extent, dt)
+            n = 10
+            foreach(_ -> add_agent!(model), 1:n)
+            listkey = :neighbors
+            cutoff = 10.0
+            neighborlist!(model, cutoff, listkey)
+            # check that the key is correctly added to the model
+            @test haskey(abmproperties(model), listkey)
+            # check that positions are correctly stored in the neighbor list
+            microbe_positions = [SVector(model[i].pos) for i in sort(collect(allids(model)))]
+            @test microbe_positions == model.neighbors.xpositions
+            # add neighbor list updater to model
+            model → (model) -> update_neighborlist!(model, listkey)
+            run!(model)
+            # after the step, the neighbor list positions should be updated to the new positions
+            microbe_positions = [SVector(model[i].pos) for i in sort(collect(allids(model)))]
+            @test microbe_positions == model.neighbors.xpositions
+            # if a microbe is removed its position is not updated anymore and ids are retained
+            j = 6
+            remove_agent!(j, model)
+            pos_removed = microbe_positions[j]
+            run!(model, 20)
+            microbe_positions = [i==j ? pos_removed : SVector(model[i].pos) for i in 1:n]
+            @test microbe_positions == model.neighbors.xpositions
+        end
+    end
+
+    @testset "UnremovableABM" begin
+        for D in 2:3
+            L = 100
+            extent = ntuple(_->L, D)
+            dt = 1
+            model = UnremovableABM(Microbe{D}, extent, dt)
+            n = 10
+            foreach(_ -> add_agent!(model), 1:n)
+            listkey = :neighbors
+            cutoff = 10.0
+            neighborlist!(model, cutoff, listkey)
+            # check that the key is correctly added to the model
+            @test haskey(abmproperties(model), listkey)
+            # check that positions are correctly stored in the neighbor list
+            microbe_positions = [SVector(model[i].pos) for i in sort(collect(allids(model)))]
+            @test microbe_positions == model.neighbors.xpositions
+            # add neighbor list updater to model
+            model → (model) -> update_neighborlist!(model, listkey)
+            run!(model)
+            # after the step, the neighbor list positions should be updated to the new positions
+            microbe_positions = [SVector(model[i].pos) for i in sort(collect(allids(model)))]
+            @test microbe_positions == model.neighbors.xpositions
+        end
+    end
+end

--- a/test/neighborlists.jl
+++ b/test/neighborlists.jl
@@ -5,7 +5,7 @@ using StaticArrays
 
 @testset "Neighbor Lists" begin
     @testset "StandardABM" begin
-        for D in 2:3
+        for D in 1:3
             L = 100
             extent = ntuple(_->L, D)
             dt = 1
@@ -14,6 +14,10 @@ using StaticArrays
             foreach(_ -> add_agent!(model), 1:n)
             listkey = :neighbors
             cutoff = 10.0
+            if D == 1
+                @test_throws ArgumentError neighborlist!(model, cutoff, listkey)
+                continue
+            end
             neighborlist!(model, cutoff, listkey)
             # check that the key is correctly added to the model
             @test haskey(abmproperties(model), listkey)
@@ -37,7 +41,7 @@ using StaticArrays
     end
 
     @testset "UnremovableABM" begin
-        for D in 2:3
+        for D in 1:3
             L = 100
             extent = ntuple(_->L, D)
             dt = 1
@@ -46,6 +50,10 @@ using StaticArrays
             foreach(_ -> add_agent!(model), 1:n)
             listkey = :neighbors
             cutoff = 10.0
+            if D == 1
+                @test_throws ArgumentError neighborlist!(model, cutoff, listkey)
+                continue
+            end
             neighborlist!(model, cutoff, listkey)
             # check that the key is correctly added to the model
             @test haskey(abmproperties(model), listkey)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Test
     include("motility.jl")
     include("microbe-creation.jl")
     include("model.jl")
+    include("neighborlists.jl")
     include("spheres.jl")
     include("analysis.jl")
 end


### PR DESCRIPTION
Closes #31.

The goal here was to address #30, so only two types of neighbor lists are supported
1. a neighbor list between all microbes in a model
2. a neighbor list between all microbes in a model and a given collection of static objects

Neighbor lists between different microbe groups might be implemented in the future (could be useful for interactions between different species or similar things).

The support is limited to 2- and 3-dimensional systems due to CellListMap.jl limitations (but it's probably not that useful for 1D systems anyway... no big deal I guess)