### PR TITLE
Chemotaxis

### DIFF
--- a/src/chemotaxis/brown-berg.jl
+++ b/src/chemotaxis/brown-berg.jl
@@ -1,4 +1,4 @@
-export BrownBerg
+export BrownBerg, chemotaxis!
 
 """
     BrownBerg{D} <: AbstractMicrobe{D}
@@ -17,7 +17,7 @@ Default parameters:
 mutable struct BrownBerg{D} <: AbstractMicrobe{D}
     id::Int
     pos::NTuple{D,Float64}
-    motility::AbstractMotility 
+    motility::AbstractMotility
     vel::NTuple{D,Float64}
     speed::Float64
     turn_rate::Float64
@@ -29,18 +29,18 @@ mutable struct BrownBerg{D} <: AbstractMicrobe{D}
     memory::Float64
 
     BrownBerg{D}(
-        id::Int = rand(1:typemax(Int32)),
-        pos::NTuple{D,<:Real} = ntuple(zero, D);
-        motility::AbstractMotility = RunTumble(),
-        vel::NTuple{D,<:Real} = rand_vel(D),
-        speed::Real = rand_speed(motility),
-        turn_rate::Real = 1/0.67,
-        rotational_diffusivity::Real = 0.035,
-        radius::Real = 0.5,
-        state::Real = 0.0,
-        gain::Real = 660.0,
-        receptor_binding_constant::Real = 100.0,
-        memory::Real = 1.0,
+        id::Int=rand(1:typemax(Int32)),
+        pos::NTuple{D,<:Real}=ntuple(zero, D);
+        motility::AbstractMotility=RunTumble(),
+        vel::NTuple{D,<:Real}=rand_vel(D),
+        speed::Real=rand_speed(motility),
+        turn_rate::Real=1 / 0.67,
+        rotational_diffusivity::Real=0.035,
+        radius::Real=0.5,
+        state::Real=0.0,
+        gain::Real=660.0,
+        receptor_binding_constant::Real=100.0,
+        memory::Real=1.0
     ) where {D} = new{D}(
         id, Float64.(pos), motility, Float64.(vel), Float64(speed), Float64(turn_rate),
         Float64(rotational_diffusivity), Float64(radius), Float64(state),
@@ -49,7 +49,7 @@ mutable struct BrownBerg{D} <: AbstractMicrobe{D}
     )
 end # struct
 
-function _affect!(microbe::BrownBerg, model)
+function chemotaxis!(microbe::BrownBerg, model)
     Δt = model.timestep
     τₘ = microbe.memory
     β = exp(-Δt / τₘ) # memory loss factor
@@ -58,15 +58,19 @@ function _affect!(microbe::BrownBerg, model)
     u = model.concentration_field(microbe.pos, model)
     ∇u = model.concentration_gradient(microbe.pos, model)
     ∂ₜu = model.concentration_time_derivative(microbe.pos, model)
-    du_dt = dot(microbe.vel, ∇u)*microbe.speed + ∂ₜu
+    du_dt = dot(microbe.vel, ∇u) * microbe.speed + ∂ₜu
     M = KD / (KD + u)^2 * du_dt # dPb/dt from new measurement
-    microbe.state = (1-β)*M + S*β # new weighted dPb/dt
+    microbe.state = (1 - β) * M + S * β # new weighted dPb/dt
     return nothing
 end # function
 
-function _turnrate(microbe::BrownBerg, model)
+function affect!(microbe::BrownBerg, model)
+    chemotaxis!(microbe, model)
+end
+
+function turnrate(microbe::BrownBerg, model)
     ν₀ = microbe.turn_rate # unbiased
     g = microbe.gain
     S = microbe.state
-    return ν₀*exp(-g*S) # modulated turn rate
+    return ν₀ * exp(-g * S) # modulated turn rate
 end # function

--- a/src/chemotaxis/xie.jl
+++ b/src/chemotaxis/xie.jl
@@ -1,4 +1,4 @@
-export Xie
+export Xie, chemotaxis!
 
 """
     Xie{D} <: AbstractMicrobe{D}
@@ -50,24 +50,24 @@ mutable struct Xie{D} <: AbstractMicrobe{D}
     chemotactic_precision::Float64
 
     Xie{D}(
-        id::Int = rand(1:typemax(Int32)),
-        pos::NTuple{D,<:Real} = ntuple(zero, D);
-        motility = RunReverseFlick(speed_forward = [46.5]),
-        vel::NTuple{D,<:Real} = rand_vel(D),
-        speed::Real = rand_speed(motility),
-        turn_rate_forward::Real = 2.3, # 1/s
-        turn_rate_backward::Real = 1.9, # 1/s
-        rotational_diffusivity::Real = 0.26, # rad²/s
-        radius::Real = 0.5, # μm
-        state::Real = 0.0, # s
-        state_m::Real = 0.0, # s
-        state_z::Real = 0.0, # s
-        adaptation_time_m::Real = 1.29, # s
-        adaptation_time_z::Real = 0.28, # s
-        gain_forward::Real = 2.7, # 1/s
-        gain_backward::Real = 1.6, # 1/s
-        binding_affinity::Real = 0.39, # μM
-        chemotactic_precision::Real = 0.0,
+        id::Int=rand(1:typemax(Int32)),
+        pos::NTuple{D,<:Real}=ntuple(zero, D);
+        motility=RunReverseFlick(speed_forward=[46.5]),
+        vel::NTuple{D,<:Real}=rand_vel(D),
+        speed::Real=rand_speed(motility),
+        turn_rate_forward::Real=2.3, # 1/s
+        turn_rate_backward::Real=1.9, # 1/s
+        rotational_diffusivity::Real=0.26, # rad²/s
+        radius::Real=0.5, # μm
+        state::Real=0.0, # s
+        state_m::Real=0.0, # s
+        state_z::Real=0.0, # s
+        adaptation_time_m::Real=1.29, # s
+        adaptation_time_z::Real=0.28, # s
+        gain_forward::Real=2.7, # 1/s
+        gain_backward::Real=1.6, # 1/s
+        binding_affinity::Real=0.39, # μM
+        chemotactic_precision::Real=0.0
     ) where {D} = new{D}(
         id, Float64.(pos), motility, Float64.(vel), Float64(speed),
         Float64(turn_rate_forward), Float64(turn_rate_backward),
@@ -81,7 +81,7 @@ end # struct
 
 
 # needs a different show because it does not have a "turn_rate" field
-function Base.show(io::IO, ::MIME"text/plain", m::Xie{D}) where D
+function Base.show(io::IO, ::MIME"text/plain", m::Xie{D}) where {D}
     println(io, "$(typeof(m)) with $(typeof(m.motility)) motility")
     println(io, "position (μm): $(r2dig.(m.pos)); velocity (μm/s): $(r2dig.(m.vel.*m.speed))")
     println(io, "average unbiased turn rate (Hz): forward $(r2dig(m.turn_rate_forward)), backward $(r2dig(m.turn_rate_backward))")
@@ -91,7 +91,7 @@ end
 
 # Xie requires its own turnrate functions
 # since it has different parameters for fw and bw states
-function _turnrate(microbe::Xie, model)
+function turnrate(microbe::Xie, model)
     if microbe.motility isa AbstractMotilityTwoStep
         return turnrate_twostep(microbe, model)
     else
@@ -107,16 +107,16 @@ function turnrate_twostep(microbe::Xie, model)
         ν₀ = microbe.turn_rate_backward
         β = microbe.gain_backward
     end
-    return ν₀*(1 + β*S)
+    return ν₀ * (1 + β * S)
 end
 function turnrate_onestep(microbe::Xie, model)
     S = microbe.state
     ν₀ = microbe.turn_rate_forward
     β = microbe.gain_forward
-    return ν₀*(1 + β*S)
+    return ν₀ * (1 + β * S)
 end
 
-function _affect!(microbe::Xie, model; ε=1e-16)
+function chemotaxis!(microbe::Xie, model; ε=1e-16)
     Δt = model.timestep
     Dc = model.compound_diffusivity
     c = model.concentration_field(microbe.pos, model)
@@ -124,18 +124,22 @@ function _affect!(microbe::Xie, model; ε=1e-16)
     a = microbe.radius
     Π = microbe.chemotactic_precision
     # noisy concentration measurement with Berg-Purcell formula
-    σ = CONV_NOISE * Π * sqrt(3*c / (5*π*Dc*a*Δt))
-    M = rand(Normal(c,σ))
-    ϕ = log(1.0 + max(M/K, -1+ε))
+    σ = CONV_NOISE * Π * sqrt(3 * c / (5 * π * Dc * a * Δt))
+    M = rand(Normal(c, σ))
+    ϕ = log(1.0 + max(M / K, -1 + ε))
     τ_m = microbe.adaptation_time_m
     τ_z = microbe.adaptation_time_z
-    a₀ = (τ_m*τ_z)/(τ_m - τ_z)
+    a₀ = (τ_m * τ_z) / (τ_m - τ_z)
     m = microbe.state_m
     z = microbe.state_z
-    m += (ϕ - m/τ_m)*Δt
-    z += (ϕ - z/τ_z)*Δt
+    m += (ϕ - m / τ_m) * Δt
+    z += (ϕ - z / τ_z) * Δt
     microbe.state_m = m
     microbe.state_z = z
-    microbe.state = a₀ * (m/τ_m - z/τ_z)
+    microbe.state = a₀ * (m / τ_m - z / τ_z)
     return nothing
+end
+
+function affect!(microbe::Xie, model)
+    chemotaxis!(microbe, model)
 end

--- a/src/microbe_step.jl
+++ b/src/microbe_step.jl
@@ -12,14 +12,14 @@ Perform an integration step for `microbe`. In order:
 function microbe_step!(microbe::AbstractMicrobe, model)
     dt = model.timestep # integration timestep
     # update microbe position
-    move_agent!(microbe, model, microbe.speed*dt)
+    move_agent!(microbe, model, microbe.speed * dt)
     # reorient through rotational diffusion
     rotational_diffusion!(microbe, model)
     # update microbe state
     affect!(microbe, model)
     # evaluate instantaneous turn rate
     ω = turnrate(microbe, model)
-    if rand(model.rng) < ω*dt # if true reorient microbe
+    if rand(model.rng) < ω * dt # if true reorient microbe
         turn!(microbe, model)
     end
     nothing
@@ -40,7 +40,7 @@ function microbe_pathfinder_step!(microbe::AbstractMicrobe, model)
     affect!(microbe, model)
     # evaluate instantaneous turn rate
     ω = turnrate(microbe, model)
-    if rand(model.rng) < ω*dt # if true reorient microbe
+    if rand(model.rng) < ω * dt # if true reorient microbe
         turn!(microbe, model)
     end
     nothing
@@ -51,12 +51,9 @@ end
     turnrate(microbe, model)
 Evaluate instantaneous turn rate of `microbe`.
 """
-turnrate(microbe::AbstractMicrobe, model) = _turnrate(microbe, model)
+turnrate(microbe::AbstractMicrobe, model) = microbe.turn_rate
 """
     affect!(microbe, model)
 Can be used to arbitrarily update `microbe` state.
 """
-affect!(microbe::AbstractMicrobe, model) = _affect!(microbe, model)
-# not exposed and can be used to restore default functionality
-_turnrate(microbe::AbstractMicrobe, model) = microbe.turn_rate
-_affect!(microbe::AbstractMicrobe, model) = nothing
+affect!(microbe::AbstractMicrobe, model) = nothing

--- a/test/model.jl
+++ b/test/model.jl
@@ -26,7 +26,7 @@ using LinearAlgebra: norm
             model = StandardABM(Microbe{D}, space, timestep; rng)
             add_agent!(model)
             rng = MersenneTwister(1234)
-            pos = Tuple(rand(rng,D) .* extent)
+            pos = Tuple(rand(rng, D) .* extent)
             vel = rand_vel(rng, D)
             speed = rand_speed(rng, RunTumble())
             @test Set(keys(model.agents)) == Set((1,))
@@ -36,7 +36,7 @@ using LinearAlgebra: norm
             @test model[1].speed == speed
             @test model[1].motility isa RunTumble
             m₀ = Microbe{D}()
-            for key in setdiff(fieldnames(Microbe{D}), (:id,:pos,:vel,:motility))
+            for key in setdiff(fieldnames(Microbe{D}), (:id, :pos, :vel, :motility))
                 @test getfield(model[1], key) == getfield(m₀, key)
             end
 
@@ -87,8 +87,8 @@ using LinearAlgebra: norm
             add_agent!(pos, model; vel=vel2, speed=speed2, turn_rate=Inf, motility=RunReverse())
             run!(model) # performs 1 microbe_step! and 1 model.update! step
             # x₁ = x₀ + vΔt
-            @test all(model[1].pos .≈ pos .+ vel1.*speed1.*dt)
-            @test all(model[2].pos .≈ pos .+ vel2.*speed2.*dt)
+            @test all(model[1].pos .≈ pos .+ vel1 .* speed1 .* dt)
+            @test all(model[2].pos .≈ pos .+ vel2 .* speed2 .* dt)
             # v is the same for the agent with zero turn rate
             @test all(model[1].vel .≈ vel1)
             # v is changed for the other agent
@@ -103,13 +103,13 @@ using LinearAlgebra: norm
 
             # customize microbe affect! function
             # decreases microbe state value by D at each step
-            MicrobeAgents.affect!(microbe::Microbe{D}, model) = (microbe.state-=D)
+            MicrobeAgents.affect!(microbe::Microbe{D}, model) = (microbe.state -= D)
             model = ABM(Microbe{D}, space, dt)
             add_agent!(model)
             run!(model)
             @test model[1].state == -D
             # restore default affect! function
-            MicrobeAgents.affect!(microbe::Microbe{D}, model) = MicrobeAgents._affect!(microbe, model)
+            MicrobeAgents.affect!(microbe::Microbe{D}, model) = nothing
             run!(model)
             # now the state has not changed from previous step
             @test model[1].state == -D
@@ -119,7 +119,7 @@ using LinearAlgebra: norm
             tick_more!(model) = (model.t += 3)
             model → tick_more! # now model.t increases by 4 (+1 +3) at each step
             run!(model, 6)
-            @test model.t == 6*4
+            @test model.t == 6 * 4
             decrease!(model) = (model.t -= 1)
             model = ABM(Microbe{D}, space, dt)
             # chain arbitrary number of functions


### PR DESCRIPTION
Improves the interface for chemotaxis and affect functions

- `_turnrate' and `_affect!` have been removed.
- all chemotaxis models now export a `chemotaxis!` function (which replaces the old `_affect!`)
- each chemotaxis model now has their own `affect!` which calls `chemotaxis!`