### PR TITLE
Simple stepping benchmarks

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,53 @@
+using BenchmarkTools
+using MicrobeAgents
+using Printf
+import Pkg
+
+#==
+##
+const SUITE = BenchmarkGroup()
+SUITE["Simple stepping"] = BenchmarkGroup()
+
+##
+microbe_types = [Microbe, BrownBerg, Brumley, Celani, Xie]
+dimensions = [1, 2, 3]
+
+for D in dimensions
+    SUITE["Simple stepping"]["$D dimensions"] = BenchmarkGroup()
+    for T in microbe_types
+        SUITE["Simple stepping"]["$D dimensions"]["$T"] = @benchmarkable(
+            run!(model, 1),
+            evals = 10,
+            samples = 1000,
+            setup = (
+                model = UnremovableABM(S, $T, dt),
+                S = ContinuousSpace(SVector{$D}(10.0 for _ in $D)),
+                dt = 0.1
+            )
+        )
+    end
+end
+==#
+
+open("benchmarks.md", "w") do io
+    @printf io "# MicrobeAgents.jl benchmarks - %s \n\n" Pkg.project().version
+end
+
+## Setup
+microbe_types = [Microbe, BrownBerg, Brumley, Celani, Xie]
+dimensions = [1, 2, 3]
+
+##
+open("benchmarks.md", "a") do io
+    @printf io "## Simple stepping\n"
+    @printf io "%-16s %-16s %-16s %-16s\n" "Type" "Time (μs)" "Allocs" "Memory"
+    for T in microbe_types
+        for D in dimensions
+            space = ContinuousSpace(ntuple(_ -> 10.0, D))
+            dt = 0.1
+            model = UnremovableABM(T{D}, space, dt)
+            b = @benchmark run!($model, $(1))
+            @printf io "%-16s %-16.2e %-16d %-16.2e\n" string(T{D}) minimum(b.times)*1e-3 b.allocs b.memory
+        end
+    end
+end

--- a/benchmark/benchmarks.md
+++ b/benchmark/benchmarks.md
@@ -1,0 +1,19 @@
+# MicrobeAgents.jl benchmarks - 0.2.0 
+
+## Simple stepping
+Type             Time (μs)        Allocs           Memory          
+Microbe{1}       2.13e+00         40               3.73e+03        
+Microbe{2}       2.34e+00         40               3.79e+03        
+Microbe{3}       2.55e+00         40               3.92e+03        
+BrownBerg{1}     2.27e+00         40               3.73e+03        
+BrownBerg{2}     2.65e+00         40               3.79e+03        
+BrownBerg{3}     2.38e+00         40               3.92e+03        
+Brumley{1}       2.27e+00         40               3.73e+03        
+Brumley{2}       2.33e+00         40               3.79e+03        
+Brumley{3}       2.55e+00         40               3.92e+03        
+Celani{1}        2.44e+00         40               3.73e+03        
+Celani{2}        2.50e+00         40               3.79e+03        
+Celani{3}        2.55e+00         40               3.92e+03        
+Xie{1}           2.51e+00         40               3.73e+03        
+Xie{2}           2.28e+00         40               3.79e+03        
+Xie{3}           2.55e+00         40               3.92e+03        


### PR DESCRIPTION
Closes #57 

Currently done using `@benchmark` and saving results to a markdown file; will be later rewritten for usage with AirspeedVelocity.jl once Agents v6 is out.