### PR TITLE
Use explicit formula for 2D rotations, quaternions for 3D rotations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,8 +13,8 @@ GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MeanSquaredDisplacement = "13c93d70-909c-440c-af92-39d48ffa2ba2"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Quaternions = "94ee1d12-ae83-5a48-8b1c-48b8ff168ae0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
@@ -22,7 +22,6 @@ Agents = "6"
 CellListMap = "0.8"
 Distributions = "0.25"
 GeometryBasics = "0.4"
-Rotations = "1"
 StaticArrays = "1"
 julia = "1"
 

--- a/src/MicrobeAgents.jl
+++ b/src/MicrobeAgents.jl
@@ -10,7 +10,7 @@ using CellListMap.PeriodicSystems
 using Distributions
 using LinearAlgebra
 using Random
-using Rotations
+using Quaternions
 using StaticArrays
 export SVector
 


### PR DESCRIPTION
- Remove dependency on `Rotations.jl`
- Use explicit `sincos` calculation for 2D rotations
- Use quaternion multiplication (from `Quaternions.jl`) for 3D rotations

The quaternion rotation seems to provide only a negligible performance benefit from the previous implementation (~5ns out of ~40ns required for the rotation). It's not crucial but the current implementation may be further improved (around half of the time is spent for `normalvector`...)